### PR TITLE
Add save and exit option

### DIFF
--- a/splatplost/gui/plotter.py
+++ b/splatplost/gui/plotter.py
@@ -267,7 +267,8 @@ class PlotterUI(Form_plotter):
                                    cursor_reset_time=1000 * int(self.cal_time.value()),
                                    stable_mode=self.stable_mode.isChecked(),
                                    clear_drawing=self.clear_drawing.isChecked(),
-                                   plot_blocks=self.RouteFile.get_selected_blocks()
+                                   plot_blocks=self.RouteFile.get_selected_blocks(),
+                                   save_and_exit=self.save_and_exit.isChecked()
                                    )
 
         worker = AsyncWorker(self, draw_func)
@@ -305,7 +306,8 @@ class PlotterUI(Form_plotter):
                                     cursor_reset_time=1000 * int(self.cal_time.value()),
                                     stable_mode=self.stable_mode.isChecked(),
                                     clear_drawing=self.clear_drawing.isChecked(),
-                                    plot_blocks=self.RouteFile.get_selected_blocks()
+                                    plot_blocks=self.RouteFile.get_selected_blocks(),
+                                    save_and_exit=self.save_and_exit.isChecked()
                                     )
 
         worker = AsyncWorker(self, draw_func)

--- a/splatplost/gui/plotter.ui
+++ b/splatplost/gui/plotter.ui
@@ -392,6 +392,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="save_and_exit">
+        <property name="text">
+         <string>Save and Exit on Completion</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="verticalSpacer_3">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -425,7 +432,7 @@
      <x>0</x>
      <y>0</y>
      <width>658</width>
-     <height>34</height>
+     <height>22</height>
     </rect>
    </property>
    <property name="defaultUp">

--- a/splatplost/keybindings.py
+++ b/splatplost/keybindings.py
@@ -20,6 +20,11 @@ class KeyBinding:
 
     @staticmethod
     @abstractmethod
+    def save() -> CommandList:
+        pass
+
+    @staticmethod
+    @abstractmethod
     def clear() -> CommandList:
         pass
 
@@ -62,6 +67,11 @@ class Splatoon2KeyBinding(KeyBinding):
 
     @staticmethod
     @abstractmethod
+    def save() -> CommandList:
+        return [Button.B]
+
+    @staticmethod
+    @abstractmethod
     def clear() -> CommandList:
         return [Button.MINUS]
 
@@ -96,6 +106,11 @@ class Splatoon3KeyBinding(KeyBinding):
 
         commands += [Button.B]
         return commands
+
+    @staticmethod
+    @abstractmethod
+    def save() -> CommandList:
+        return [Button.MINUS]
 
     @staticmethod
     @abstractmethod

--- a/splatplost/plot.py
+++ b/splatplost/plot.py
@@ -256,7 +256,7 @@ def partial_erase(order_file: str, backend: Type[NXWrapper], delay_ms: int = 100
 
 def partial_erase_with_conn(connection: NXWrapper, key_binding: KeyBinding, horizontal_divider: int,
                             vertical_divider: int, cursor_reset, cursor_reset_time, stable_mode: bool = False,
-                            clear_drawing: bool = False, plot_blocks: list[int] = None) -> None:
+                            clear_drawing: bool = False, plot_blocks: list[int] = None, save_and_exit: bool = False) -> None:
     """
     Clean blocks.
 
@@ -269,6 +269,7 @@ def partial_erase_with_conn(connection: NXWrapper, key_binding: KeyBinding, hori
     :param stable_mode: Whether to use stable mode.
     :param clear_drawing: Whether to clear the plot before plotting.
     :param plot_blocks: The blocks to plot.
+    :param save_and_exit: Whether to save an exit after completing plotting.
     """
 
     # Goto (0,0) point
@@ -291,10 +292,13 @@ def partial_erase_with_conn(connection: NXWrapper, key_binding: KeyBinding, hori
                                                      )
         execute_command_list(command_list, connection, stable_mode=stable_mode)
 
+    if save_and_exit:
+        execute_command_list(key_binding.save(), connection, stable_mode=stable_mode)
+
 
 def partial_plot_with_conn(connection: NXWrapper, blocks, key_binding: KeyBinding, cursor_reset, cursor_reset_time,
                            stable_mode: bool = False, clear_drawing: bool = False,
-                           plot_blocks: list[int] = None) -> None:
+                           plot_blocks: list[int] = None, save_and_exit: bool = False) -> None:
     """
     Plot blocks.
 
@@ -306,6 +310,7 @@ def partial_plot_with_conn(connection: NXWrapper, blocks, key_binding: KeyBindin
     :param stable_mode: Whether to use stable mode.
     :param clear_drawing: Whether to clear the plot before plotting.
     :param plot_blocks: The blocks to plot.
+    :param save_and_exit: Whether to save an exit after completing plotting.
     """
     # Goto (0,0) point
     command_list, current_position = reset_cursor_position((0, 0), (0, 0), cursor_reset_time)
@@ -326,6 +331,9 @@ def partial_plot_with_conn(connection: NXWrapper, blocks, key_binding: KeyBindin
                                                     cursor_reset=cursor_reset, cursor_reset_time=10000
                                                     )
         execute_command_list(command_list, connection, stable_mode=stable_mode)
+
+    if save_and_exit:
+        execute_command_list(key_binding.save(), connection, stable_mode=stable_mode)
 
 
 def partial_plot(order_file: str, backend: Type[NXWrapper], delay_ms: int = 100, press_duration_ms: int = 100,


### PR DESCRIPTION
Added a checkbox to the GUI to toggle pressing the save and exit button after drawing/erasing is complete. I had an unfortunate incident where I left a drawing going for a few hours, and when I came back, the switch was asleep because it had stopped receiving input. As soon as I woke it up, I got booted from the drawing without being able to save the results. I added this to prevent that, and I thought it might be helpful for others too.

*Note*: I only tested this in Splatoon 3, not 2.